### PR TITLE
OB-1 Summaries of `comments` and `likes` are fetched for each FB post

### DIFF
--- a/server/lib/facebook/facebook_scraper.js
+++ b/server/lib/facebook/facebook_scraper.js
@@ -19,9 +19,15 @@ import FeedStream from './feed_stream';
 const FEED_DIRECTORY = './feed/facebook/';
 const FEED_FILE_FORMATTING_OPTIONS = { spaces: 2 };
 
+/**
+* Returns default parameters of Facebook API call. Since we are not interested
+* in actual authors of comments and likes of a given post but only in the `total_count`
+* number (which is provided in `summary`), both `comments` and 'likes' fields are limited to 0.
+*/
 function getDefaultRequestParams() {
   return {
-    // fields: 'likes.summary(true)',
+    fields: ['message', 'created_time', 'comments.limit(0).summary(true)',
+            'likes.limit(0).summary(true)', 'link', 'message_tags'].join(','),
     since: moment().subtract({ h: 24 }).toISOString(),
     limit: 100,
   };

--- a/test/server/lib/facebook/facebook_scraper.test.js
+++ b/test/server/lib/facebook/facebook_scraper.test.js
@@ -78,6 +78,8 @@ describe('FacebookScraper', () => {
   describe('_buildRequestUrl', () => {
     const currentTime = '2016-03-26T05:50:25.300Z';
     const expectedSinceParam = '2016-03-25T05:50:25.300Z';
+    const expectedFielsParam = ['message', 'created_time', 'comments.limit(0).summary(true)',
+            'likes.limit(0).summary(true)', 'link', 'message_tags'].join(',');
 
     beforeEach(() => {
       sandbox.useFakeTimers(new Date(currentTime).valueOf());
@@ -87,6 +89,7 @@ describe('FacebookScraper', () => {
       const expectedUrl = [
         `${fakeAccount}/feed?`,
         `access_token=${fakeToken}`,
+        `&fields=${expectedFielsParam}`,
         `&since=${expectedSinceParam}&limit=100`,
       ].join('');
       const actualUrl = scraper._buildRequestUrl();


### PR DESCRIPTION
- added `comments` and `likes` to the `fields` parameters of Facebook feed call;
  in both cases only the summary (containing `total_count` param) is
  fetched,
- feed has been also extended with `link` and `message_tags` parameters.
