### PR TITLE
OB-8 Configured coveralls integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,6 @@ node_js:
 install:
   - npm install
 script:
-   - npm run lint && npm test
+  - npm run lint && npm run analyze-coverage
+after_script:
+  - "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 [![Build Status](https://travis-ci.org/johnjs/observer-backend.svg?branch=master)](https://travis-ci.org/johnjs/observer-backend)
+[![Coverage Status](https://coveralls.io/repos/github/johnjs/observer-backend/badge.svg?branch=master)](https://coveralls.io/github/johnjs/observer-backend?branch=master)

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "babel-register": "^6.7.2",
     "chai": "^3.5.0",
+    "coveralls": "^2.11.9",
     "eslint": "^2.4.0",
     "eslint-config-airbnb": "^6.1.0",
     "eslint-plugin-react": "^4.2.3",


### PR DESCRIPTION
Hi @asiakaczmar!
- test coverage statistics are analysed by [coveralls](https://coveralls.io/github/johnjs/observer-backend),
- added a test coverage badge in README file.

@asiakaczmar, could you have a look, please? :)
