### PR TITLE
OB-18 Used diehard module to close queue/db connections when the app process is killed

### DIFF
--- a/lib/start.js
+++ b/lib/start.js
@@ -3,6 +3,9 @@
  **/
 import * as db from './storage/clients/db';
 import scheduler from './jobs/scheduler';
+import diehard from 'diehard';
+
+diehard.listen();
 
 db.connect();
 scheduler.scheduleJobs();

--- a/lib/storage/clients/db.js
+++ b/lib/storage/clients/db.js
@@ -3,6 +3,7 @@
 **/
 
 import mongoose from 'mongoose';
+import diehard from 'diehard';
 import logger from '../../utils/logger';
 import config from '../../config/config';
 import scrapingJobSchema from '../../jobs/scraping_job_schema';
@@ -47,9 +48,10 @@ function connect() {
     logger.logInfo('Mongoose connection disconnected');
   });
 
-  process.on('SIGINT', () => {
+  diehard.register((done) => {
     connection.close(() => {
       logger.logInfo('Mongoose connection disconnected due to app termination');
+      done();
     });
   });
 

--- a/lib/storage/clients/queue.js
+++ b/lib/storage/clients/queue.js
@@ -1,10 +1,10 @@
 /**
  * Module establishes connection with RabbitMQ.
  **/
-
 import ampq from 'amqplib';
+import diehard from 'diehard';
+import logger from '../../utils/logger';
 import config from '../../config/config';
-
 
 /**
  * Creates a RabbitMQ connection basing on paramters taken from the config module.
@@ -17,7 +17,15 @@ function createConnection() {
   const port = config.get('RABBIT_PORT');
   const uri = `amqp://${user}:${pwd}@${host}:${port}`;
 
-  return ampq.connect(uri);
+  return ampq.connect(uri).then((connection) => {
+    diehard.register((done) => {
+      connection.close().then(() => {
+        logger.logInfo('RabbitMQ connection disconnected due to app termination');
+        done();
+      });
+    });
+    return connection;
+  });
 }
 
 export { createConnection };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "babel-preset-es2015": "^6.6.0",
     "commander": "^2.9.0",
     "cron": "^1.1.0",
+    "diehard": "^1.5.1",
     "dotenv": "^2.0.0",
     "event-stream": "^3.3.2",
     "fbgraph": "^1.1.0",

--- a/test/lib/scrapers/feed_output_stream_factory.test.js
+++ b/test/lib/scrapers/feed_output_stream_factory.test.js
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import * as sinon from 'sinon';
+import fs from 'fs';
 import Q from 'q';
 import config from '../../../lib/config/config.js';
 import FeedOutputStreamFactory from '../../../lib/scrapers/feed_output_stream_factory';
@@ -43,6 +44,7 @@ describe('feed_output_stream_factory', () => {
     describe('when the FEED_DESTINATION config variable equals FILE', () => {
       it('returns a promise resolving to instance of FileFeedOutputStream', (done) => {
         sandbox.stub(config, 'get').withArgs('FEED_DESTINATION').returns('FILE');
+        sandbox.stub(fs, 'createWriteStream');
         FeedOutputStreamFactory.getStream(fakeAccount, fakeSource).then((stream) => {
           assert.instanceOf(stream, FileFeedOutputStream);
           done();

--- a/test/lib/storage/clients/db.test.js
+++ b/test/lib/storage/clients/db.test.js
@@ -1,5 +1,6 @@
 import EventEmitter from 'events';
 import mongoose from 'mongoose';
+import diehard from 'diehard';
 import { assert } from 'chai';
 import * as sinon from 'sinon';
 import logger from '../../../../lib/utils/logger';
@@ -20,6 +21,7 @@ describe('db', () => {
 
     sandbox.stub(logger, 'logError');
     sandbox.stub(logger, 'logInfo');
+    sandbox.stub(diehard, 'register');
   });
 
   afterEach(() => {
@@ -69,16 +71,13 @@ describe('db', () => {
       });
     });
 
-    it('adds a listener to process SIGINT event which closes the db connection', (done) => {
-      process.on = sandbox.stub().yieldsAsync();
-
-      db.connect();
-
-      process.nextTick(() => {
+    it('registers a diehard listener for `process killed/interrupted` events '
+          + 'which closes the db connection', (done) => {
+      diehard.register.callsArgWithAsync(0, () => {
         assert.ok(connectionStub.close.calledOnce);
-        assert.ok(logger.logInfo.calledOnce);
         done();
       });
+      db.connect();
     });
   });
 

--- a/test/lib/storage/clients/queue.test.js
+++ b/test/lib/storage/clients/queue.test.js
@@ -1,7 +1,9 @@
-import { assert } from 'chai';
-import * as sinon from 'sinon';
+import diehard from 'diehard';
 import Q from 'q';
 import ampq from 'amqplib';
+import { assert } from 'chai';
+import * as sinon from 'sinon';
+import logger from '../../../../lib/utils/logger';
 import * as queue from '../../../../lib/storage/clients/queue';
 
 describe('queue', () => {
@@ -16,17 +18,33 @@ describe('queue', () => {
   });
 
   describe('createConnection', () => {
-    const fakeChannel = { name: 'frederico' };
+    let fakeConnection;
 
     beforeEach(() => {
-      sandbox.stub(ampq, 'connect').returns(new Q(fakeChannel));
+      fakeConnection = {
+        close: sandbox.stub().returns(new Q()),
+      };
+      sandbox.stub(ampq, 'connect').returns(new Q(fakeConnection));
+      sandbox.stub(diehard, 'register');
     });
 
     it('returns a promise resolving with a rabbitmq channel', (done) => {
-      queue.createConnection().then((actualChannel) => {
-        assert.equal(actualChannel, fakeChannel);
+      queue.createConnection().then((actualConnection) => {
+        assert.equal(actualConnection, fakeConnection);
         done();
       });
+    });
+
+    it('registers a diehard listener for `process killed/interrupted` events '
+          + 'which closes the queue connection', (done) => {
+      const expecteMsg = 'RabbitMQ connection disconnected due to app termination';
+      sandbox.stub(logger, 'logInfo');
+
+      diehard.register.callsArgWithAsync(0, () => {
+        assert.ok(logger.logInfo.calledWith(expecteMsg));
+        done();
+      });
+      queue.createConnection();
     });
   });
 });

--- a/test/lib/storage/file_feed_output_stream.test.js
+++ b/test/lib/storage/file_feed_output_stream.test.js
@@ -24,6 +24,7 @@ describe('file_feed_output_stream', () => {
   describe('constructor', () => {
     beforeEach(() => {
       sandbox.useFakeTimers(new Date('2016-04-20T13:58:51.084Z').getTime());
+      sandbox.stub(fs, 'createWriteStream').returns({});
       stream = new FileFeedOutputStream(fakeAccount, fakeSource);
     });
 
@@ -38,7 +39,7 @@ describe('file_feed_output_stream', () => {
     it('initialises the file output stream', () => {
       const expectedPath = './feed/corleone_family/tom_hagen_2016-04-20T13:58:51.084Z.json';
       assert.isDefined(stream.fileStream);
-      assert.equal(stream.fileStream.path, expectedPath);
+      assert.ok(fs.createWriteStream.calledWith(expectedPath));
     });
   });
 


### PR DESCRIPTION
Hi,
In one my previous PRs I added listeners to `SIGINT` event which were supposed to close db/queue connections if the app process had been killed by `ctrl+c` command.
According to [node.js docs](https://nodejs.org/api/process.html#process_signal_events) if you install a listener for `SIGINT` or `SIGTERM`, node.js doesn't exit when the event occurs. As a consequence in our case the app process could not be killed by a single `ctrl+c` action.
To address this problem I've decided to use [diehard](https://www.npmjs.com/package/diehard) module which lets you define asynchronous handlers for `SIGINT`, `SIGQUIT`, and `SIGTERM` events. If one of the events is triggered, `diehard` runs the handlers (closes existing connections) and runs `process.exit()` command.

[--> Trello ticket](https://trello.com/c/K7ud09mo/21-ob-18-onc.e-the-app-is-started-using-nf-start-command-the-developer-needs-to-type-ctrl-c-twice-to-kill-all-the-processes)
